### PR TITLE
Remove static buffers

### DIFF
--- a/examples/gadget-ffs.c
+++ b/examples/gadget-ffs.c
@@ -41,7 +41,7 @@ int main(void)
 	int ret = -EINVAL;
 	int usbg_ret;
 	usbg_function_attrs f_attrs = {
-		.ffs = {
+		.attrs.ffs = {
 			.dev_name = "my_awesome_dev_name",
 		},
 	};

--- a/examples/show-gadgets.c
+++ b/examples/show-gadgets.c
@@ -132,6 +132,8 @@ void show_function(usbg_function *f)
 	default:
 		fprintf(stdout, "    UNKNOWN\n");
 	}
+
+	usbg_cleanup_function_attrs(&f_attrs);
 }
 
 void show_config(usbg_config *c)

--- a/examples/show-gadgets.c
+++ b/examples/show-gadgets.c
@@ -104,30 +104,30 @@ void show_function(usbg_function *f)
 
 	fprintf(stdout, "  Function, type: %s instance: %s\n",
 			usbg_get_function_type_str(type), instance);
-	switch (type) {
-	case F_SERIAL:
-	case F_ACM:
-	case F_OBEX:
+	switch (f_attrs.header.attrs_type) {
+	case USBG_F_ATTRS_SERIAL:
 		fprintf(stdout, "    port_num\t\t%d\n",
-				f_attrs.serial.port_num);
+				f_attrs.attrs.serial.port_num);
 		break;
-	case F_ECM:
-	case F_SUBSET:
-	case F_NCM:
-	case F_EEM:
-	case F_RNDIS:
+
+	case USBG_F_ATTRS_NET:
+	{
+		usbg_f_net_attrs *f_net_attrs = &f_attrs.attrs.net;
+
 		fprintf(stdout, "    dev_addr\t\t%s\n",
-				ether_ntoa(&f_attrs.net.dev_addr));
+			ether_ntoa(&f_net_attrs->dev_addr));
 		fprintf(stdout, "    host_addr\t\t%s\n",
-				ether_ntoa(&f_attrs.net.host_addr));
-		fprintf(stdout, "    ifname\t\t%s\n", f_attrs.net.ifname);
-		fprintf(stdout, "    qmult\t\t%d\n", f_attrs.net.qmult);
+			ether_ntoa(&f_net_attrs->host_addr));
+		fprintf(stdout, "    ifname\t\t%s\n", f_net_attrs->ifname);
+		fprintf(stdout, "    qmult\t\t%d\n", f_net_attrs->qmult);
 		break;
-	case F_PHONET:
-		fprintf(stdout, "    ifname\t\t%s\n", f_attrs.phonet.ifname);
+	}
+	case USBG_F_ATTRS_PHONET:
+		fprintf(stdout, "    ifname\t\t%s\n", f_attrs.attrs.phonet.ifname);
 		break;
-	case F_FFS:
-		fprintf(stdout, "    dev_name\t\t%s\n", f_attrs.ffs.dev_name);
+
+	case USBG_F_ATTRS_FFS:
+		fprintf(stdout, "    dev_name\t\t%s\n", f_attrs.attrs.ffs.dev_name);
 		break;
 	default:
 		fprintf(stdout, "    UNKNOWN\n");

--- a/include/usbg/usbg.h
+++ b/include/usbg/usbg.h
@@ -207,7 +207,7 @@ typedef struct {
  * @brief Attributes for the phonet USB function
  */
 typedef struct {
-	char ifname[USBG_MAX_STR_LENGTH];
+	char *ifname;
 } usbg_f_phonet_attrs;
 
 /**

--- a/include/usbg/usbg.h
+++ b/include/usbg/usbg.h
@@ -229,6 +229,13 @@ typedef union {
 	usbg_f_ffs_attrs ffs;
 } usbg_function_attrs;
 
+typedef enum {
+	USBG_F_ATTRS_SERIAL = 1,
+	USBG_F_ATTRS_NET,
+	USBG_F_ATTRS_PHONET,
+	USBG_F_ATTRS_FFS,
+} usbg_f_attrs_type;
+
 /* Error codes */
 
 /**
@@ -686,6 +693,13 @@ extern const char *usbg_get_function_type_str(usbg_function_type type);
  * @return Function type enum or negative error code
  */
 extern int usbg_lookup_function_type(const char *name);
+
+/**
+ * @brief Lookup attrs type for given type of function
+ * @param f_type type of functions
+ * @return Attributes type for this type of function
+ */
+extern int usbg_lookup_function_attrs_type(int f_type);
 
 /* USB configurations allocation and configuration */
 

--- a/include/usbg/usbg.h
+++ b/include/usbg/usbg.h
@@ -227,7 +227,7 @@ typedef union {
 	usbg_f_net_attrs net;
 	usbg_f_phonet_attrs phonet;
 	usbg_f_ffs_attrs ffs;
-} usbg_function_attrs;
+} usbg_f_attrs;
 
 typedef enum {
 	USBG_F_ATTRS_SERIAL = 1,
@@ -235,6 +235,15 @@ typedef enum {
 	USBG_F_ATTRS_PHONET,
 	USBG_F_ATTRS_FFS,
 } usbg_f_attrs_type;
+
+typedef struct {
+	int attrs_type;
+} usbg_f_attrs_header;
+
+typedef struct {
+	usbg_f_attrs_header header;
+	usbg_f_attrs attrs;
+} usbg_function_attrs;
 
 /* Error codes */
 

--- a/include/usbg/usbg.h
+++ b/include/usbg/usbg.h
@@ -217,7 +217,7 @@ typedef struct {
  * on config fs.
  */
 typedef struct {
-	char dev_name[USBG_MAX_DEV_LENGTH];
+	char *dev_name;
 } usbg_f_ffs_attrs;
 
 /**

--- a/include/usbg/usbg.h
+++ b/include/usbg/usbg.h
@@ -710,6 +710,16 @@ extern int usbg_lookup_function_type(const char *name);
  */
 extern int usbg_lookup_function_attrs_type(int f_type);
 
+/**
+ * @brief Cleanup content of function attributes
+ * @param f_attrs function attributes which should be cleaned up.
+ * @note This function should be called to free
+ * additional memory allocated by usbg_get_function_attrs().
+ * @warning None of attributes in passed structure should be
+ * accessed after returning from this function.
+ */
+extern void usbg_cleanup_function_attrs(usbg_function_attrs *f_attrs);
+
 /* USB configurations allocation and configuration */
 
 /**

--- a/include/usbg/usbg.h
+++ b/include/usbg/usbg.h
@@ -49,6 +49,8 @@ extern "C" {
 #define USBG_MAX_NAME_LENGTH 40
 /* Dev name for ffs is a part of function name, we subtracs 4 char for "ffs." */
 #define USBG_MAX_DEV_LENGTH (USBG_MAX_NAME_LENGTH - 4)
+/* ConfigFS just like SysFS uses page size as max size of file content */
+#define USBG_MAX_FILE_SIZE 4096
 
 /**
  * @brief Additional option for usbg_rm_* functions.
@@ -196,7 +198,7 @@ typedef struct {
 typedef struct {
 	struct ether_addr dev_addr;
 	struct ether_addr host_addr;
-	char ifname[USBG_MAX_STR_LENGTH];
+	char *ifname;
 	int qmult;
 } usbg_f_net_attrs;
 

--- a/src/usbg.c
+++ b/src/usbg.c
@@ -760,7 +760,7 @@ static int usbg_rm_all_dirs(const char *path)
 }
 
 static int usbg_parse_function_net_attrs(usbg_function *f,
-		usbg_function_attrs *f_attrs)
+		usbg_f_net_attrs *f_net_attrs)
 {
 	struct ether_addr *addr;
 	struct ether_addr addr_buf;
@@ -773,7 +773,7 @@ static int usbg_parse_function_net_attrs(usbg_function *f,
 
 	addr = ether_aton_r(str_addr, &addr_buf);
 	if (addr) {
-		f_attrs->net.dev_addr = *addr;
+		f_net_attrs->dev_addr = *addr;
 	} else {
 		ret = USBG_ERROR_IO;
 		goto out;
@@ -785,17 +785,17 @@ static int usbg_parse_function_net_attrs(usbg_function *f,
 
 	addr = ether_aton_r(str_addr, &addr_buf);
 	if (addr) {
-		f_attrs->net.host_addr = *addr;
+		f_net_attrs->host_addr = *addr;
 	} else {
 		ret = USBG_ERROR_IO;
 		goto out;
 	}
 
-	ret = usbg_read_string(f->path, f->name, "ifname", f_attrs->net.ifname);
+	ret = usbg_read_string(f->path, f->name, "ifname", f_net_attrs->ifname);
 	if (ret != USBG_SUCCESS)
 		goto out;
 
-	ret = usbg_read_dec(f->path, f->name, "qmult", &(f_attrs->net.qmult));
+	ret = usbg_read_dec(f->path, f->name, "qmult", &(f_net_attrs->qmult));
 
 out:
 	return ret;
@@ -818,7 +818,7 @@ static int usbg_parse_function_attrs(usbg_function *f,
 	case F_NCM:
 	case F_EEM:
 	case F_RNDIS:
-		ret = usbg_parse_function_net_attrs(f, f_attrs);
+		ret = usbg_parse_function_net_attrs(f, &(f_attrs->net));
 		break;
 	case F_PHONET:
 		ret = usbg_read_string(f->path, f->name, "ifname",

--- a/src/usbg.c
+++ b/src/usbg.c
@@ -224,6 +224,36 @@ const char *usbg_strerror(usbg_error e)
 	return ret;
 }
 
+int usbg_lookup_function_attrs_type(int f_type)
+{
+	int ret;
+
+	switch (f_type) {
+	case F_SERIAL:
+	case F_ACM:
+	case F_OBEX:
+		ret = USBG_F_ATTRS_SERIAL;
+		break;
+	case F_ECM:
+	case F_SUBSET:
+	case F_NCM:
+	case F_EEM:
+	case F_RNDIS:
+		ret = USBG_F_ATTRS_NET;
+		break;
+	case F_PHONET:
+		ret = USBG_F_ATTRS_PHONET;
+		break;
+	case F_FFS:
+		ret = USBG_F_ATTRS_PHONET;
+		break;
+	default:
+		ret = USBG_ERROR_NOT_SUPPORTED;
+	}
+
+	return ret;
+}
+
 int usbg_lookup_function_type(const char *name)
 {
 	int i = USBG_FUNCTION_TYPE_MIN;

--- a/src/usbg.c
+++ b/src/usbg.c
@@ -879,8 +879,8 @@ static int usbg_parse_function_attrs(usbg_function *f,
 
 	case USBG_F_ATTRS_PHONET:
 		f_attrs->header.attrs_type = USBG_F_ATTRS_PHONET;
-		ret = usbg_read_string(f->path, f->name, "ifname",
-				f_attrs->attrs.phonet.ifname);
+		ret = usbg_read_string_alloc(f->path, f->name, "ifname",
+					     &(f_attrs->attrs.phonet.ifname));
 		break;
 
 	case USBG_F_ATTRS_FFS:
@@ -2618,6 +2618,8 @@ void usbg_cleanup_function_attrs(usbg_function_attrs *f_attrs)
 		break;
 
 	case USBG_F_ATTRS_PHONET:
+		free(f_attrs->attrs.phonet.ifname);
+		f_attrs->attrs.phonet.ifname = NULL;
 		break;
 
 	case USBG_F_ATTRS_FFS:
@@ -2688,8 +2690,8 @@ int usbg_set_function_attrs(usbg_function *f,
 	case USBG_F_ATTRS_PHONET:
 		/* ifname attribute is read only
 		 * so we accept only empty string */
-		ret = f_attrs->attrs.phonet.ifname[0] ? USBG_ERROR_INVALID_PARAM
-			: USBG_SUCCESS;
+		ret = f_attrs->attrs.phonet.ifname && f_attrs->attrs.phonet.ifname[0] ?
+			USBG_ERROR_INVALID_PARAM : USBG_SUCCESS;
 		break;
 
 	case USBG_F_ATTRS_FFS:

--- a/src/usbg.c
+++ b/src/usbg.c
@@ -2581,6 +2581,29 @@ int usbg_get_function_attrs(usbg_function *f, usbg_function_attrs *f_attrs)
 			: USBG_ERROR_INVALID_PARAM;
 }
 
+void usbg_cleanup_function_attrs(usbg_function_attrs *f_attrs)
+{
+	if (!f_attrs)
+		return;
+
+	switch (f_attrs->header.attrs_type) {
+	case USBG_F_ATTRS_SERIAL:
+		break;
+
+	case USBG_F_ATTRS_NET:
+		break;
+
+	case USBG_F_ATTRS_PHONET:
+		break;
+
+	case USBG_F_ATTRS_FFS:
+		break;
+	default:
+		ERROR("Unsupported attrs type\n");
+		break;
+	}
+}
+
 int usbg_set_function_net_attrs(usbg_function *f, const usbg_f_net_attrs *attrs)
 {
 	int ret = USBG_SUCCESS;

--- a/src/usbg_schemes_libconfig.c
+++ b/src/usbg_schemes_libconfig.c
@@ -397,6 +397,7 @@ static int usbg_export_function_attrs(usbg_function *f, config_setting_t *root)
 		ret = USBG_ERROR_NOT_SUPPORTED;
 	}
 
+	usbg_cleanup_function_attrs(&f_attrs);
 out:
 	return ret;
 }


### PR DESCRIPTION
This series removes static buffers from function attributes. This will allow to implement support for more complicated functions like mass storage and UVC.

@dsacre
@philippedeswert
@pszewczyk
As you are most active community members would you mind if I ask you to do a code review?

@gregkh
This is the API change which I mentioned in https://github.com/libusbg/libusbg/pull/15 