### PR TITLE
Minor fixes and improvments

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -37,8 +37,6 @@ AS_IF([test "x$with_libconfig" = xyes], [
 AS_IF([test "x$enable_tests" = xyes], [
 	PKG_CHECK_MODULES([CMOCKA], [cmocka >= 0.4.1],
 			  AC_DEFINE(HAS_CMOCKA, 1, [detected cmocka]))
-	CFLAGS="$CFLAGS $CMOCKA_CFLAGS"
-	LIBS="$LIBS $CMOCKA_LIBS"
 	AC_CONFIG_FILES([tests/Makefile])
 ])
 AM_CONDITIONAL(BUILD_TESTS, [test "x$enable_tests" = xyes])

--- a/include/usbg/usbg_internal.h
+++ b/include/usbg/usbg_internal.h
@@ -74,6 +74,8 @@ struct usbg_config
 	int id;
 };
 
+typedef int (*usbg_rm_function_callback)(usbg_function *, int);
+
 struct usbg_function
 {
 	TAILQ_ENTRY(usbg_function) fnode;
@@ -85,6 +87,7 @@ struct usbg_function
 	/* Only for internal library usage */
 	char *label;
 	usbg_function_type type;
+	usbg_rm_function_callback rm_callback;
 };
 
 struct usbg_binding

--- a/include/usbg/usbg_internal.h
+++ b/include/usbg/usbg_internal.h
@@ -28,6 +28,16 @@
  * @file include/usbg/usbg_internal.h
  */
 
+#ifndef offsetof
+#define offsetof(type, member)  __builtin_offsetof (type, member)
+#endif /* offsetof */
+
+#ifndef container_of
+#define container_of(ptr, type, field) ({                               \
+                        const typeof(((type *)0)->field) *member = (ptr); \
+                        (type *)( (char *)member - offsetof(type, field) ); \
+                })
+#endif /* container_of */
 
 struct usbg_state
 {

--- a/src/usbg.c
+++ b/src/usbg.c
@@ -1354,8 +1354,17 @@ static int usbg_parse_state(usbg_state *s)
 {
 	int ret = USBG_SUCCESS;
 
+	/*
+	 * USBG_ERROR_NOT_FOUND is returned if we are runing on machine where
+	 * there is no udc support in kernel (no /sys/class/udc dir).
+	 * This check allows to run library on such machine or if we don't
+	 * have rights to read this directory.
+	 * User will be able to finish init function and manage gadgets but
+	 * wont be able to bind it as there is no UDC.
+	 */
 	ret = usbg_parse_udcs(s);
-	if (ret != USBG_SUCCESS) {
+	if (ret != USBG_SUCCESS && ret != USBG_ERROR_NOT_FOUND &&
+		ret != USBG_ERROR_NO_ACCESS) {
 		ERROR("Unable to parse udcs");
 		goto out;
 	}

--- a/src/usbg.c
+++ b/src/usbg.c
@@ -26,6 +26,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include <ctype.h>
+#include <stdbool.h>
 #include "usbg/usbg_internal.h"
 
 /**
@@ -433,6 +434,21 @@ static int usbg_read_int(const char *path, const char *name, const char *file,
 #define usbg_read_dec(p, n, f, d)	usbg_read_int(p, n, f, 10, d)
 #define usbg_read_hex(p, n, f, d)	usbg_read_int(p, n, f, 16, d)
 
+static int usbg_read_bool(const char *path, const char *name, const char *file,
+			  bool *dest)
+{
+	int buf;
+	int ret;
+
+	ret = usbg_read_dec(path, name, file, &buf);
+	if (ret != USBG_SUCCESS)
+		goto out;
+
+	*dest = !!buf;
+out:
+	return ret;
+}
+
 static int usbg_read_string(const char *path, const char *name,
 			    const char *file, char *buf)
 {
@@ -521,6 +537,7 @@ static int usbg_write_int(const char *path, const char *name, const char *file,
 #define usbg_write_hex(p, n, f, v)	usbg_write_int(p, n, f, v, "0x%x\n")
 #define usbg_write_hex16(p, n, f, v)	usbg_write_int(p, n, f, v, "0x%04x\n")
 #define usbg_write_hex8(p, n, f, v)	usbg_write_int(p, n, f, v, "0x%02x\n")
+#define usbg_write_bool(p, n, f, v)	usbg_write_dec(p, n, f, !!v)
 
 static inline int usbg_write_string(const char *path, const char *name,
 				    const char *file, const char *buf)

--- a/src/usbg.c
+++ b/src/usbg.c
@@ -2615,26 +2615,30 @@ int usbg_get_function_attrs(usbg_function *f, usbg_function_attrs *f_attrs)
 
 void usbg_cleanup_function_attrs(usbg_function_attrs *f_attrs)
 {
+	usbg_f_attrs *attrs;
+
 	if (!f_attrs)
 		return;
+
+	attrs = &f_attrs->attrs;
 
 	switch (f_attrs->header.attrs_type) {
 	case USBG_F_ATTRS_SERIAL:
 		break;
 
 	case USBG_F_ATTRS_NET:
-		free(f_attrs->attrs.net.ifname);
-		f_attrs->attrs.net.ifname = NULL;
+		free(attrs->net.ifname);
+		attrs->net.ifname = NULL;
 		break;
 
 	case USBG_F_ATTRS_PHONET:
-		free(f_attrs->attrs.phonet.ifname);
-		f_attrs->attrs.phonet.ifname = NULL;
+		free(attrs->phonet.ifname);
+		attrs->phonet.ifname = NULL;
 		break;
 
 	case USBG_F_ATTRS_FFS:
-		free(f_attrs->attrs.ffs.dev_name);
-		f_attrs->attrs.ffs.dev_name = NULL;
+		free(attrs->ffs.dev_name);
+		attrs->ffs.dev_name = NULL;
 		break;
 	default:
 		ERROR("Unsupported attrs type\n");

--- a/src/usbg_schemes_libconfig.c
+++ b/src/usbg_schemes_libconfig.c
@@ -386,7 +386,6 @@ static int usbg_export_function_attrs(usbg_function *f, config_setting_t *root)
 
 	case USBG_F_ATTRS_PHONET:
 		/* Don't export ifname because it is read only */
-		break;
 	case USBG_F_ATTRS_FFS:
 		/* We don't need to export ffs attributes
 		 * due to instance name export */


### PR DESCRIPTION
This series fixes a few minor issues:
- linking libusbg with cmocka
- error returning while exporting phonet attributes
- code improvements
- add container_of() and offsetoff() macros
- rework of usbg_read_buf() to accept also empty files
- add function for reading and writting bool values to file
- add rm callback which can be used by comosed functions like mass storage to clean up their attributes