### PR TITLE
Add support for mass storage

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -37,8 +37,6 @@ AS_IF([test "x$with_libconfig" = xyes], [
 AS_IF([test "x$enable_tests" = xyes], [
 	PKG_CHECK_MODULES([CMOCKA], [cmocka >= 0.4.1],
 			  AC_DEFINE(HAS_CMOCKA, 1, [detected cmocka]))
-	CFLAGS="$CFLAGS $CMOCKA_CFLAGS"
-	LIBS="$LIBS $CMOCKA_LIBS"
 	AC_CONFIG_FILES([tests/Makefile])
 ])
 AM_CONDITIONAL(BUILD_TESTS, [test "x$enable_tests" = xyes])

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -1,4 +1,4 @@
-bin_PROGRAMS = show-gadgets gadget-acm-ecm gadget-vid-pid-remove gadget-ffs gadget-export gadget-import show-udcs
+bin_PROGRAMS = show-gadgets gadget-acm-ecm gadget-vid-pid-remove gadget-ffs gadget-export gadget-import show-udcs gadget-ms
 gadget_acm_ecm_SOURCES = gadget-acm-ecm.c
 show_gadgets_SOURCES = show-gadgets.c
 gadget_vid_pid_remove_SOURCES = gadget-vid-pid-remove.c

--- a/examples/gadget-ms.c
+++ b/examples/gadget-ms.c
@@ -1,0 +1,159 @@
+/*
+ * Copyright (C) 2014 Samsung Electronics
+ *
+ * Krzysztof Opasiak <k.opasiak@samsung.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+/**
+ * @file gadget-ms.c
+ * @example gadget-ms.c
+ * This is an example of how to create gadget with mass storage function
+ * with two luns.
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include <usbg/usbg.h>
+
+#define VENDOR          0x1d6b
+#define PRODUCT         0x0104
+
+int main(int argc, char **argv)
+{
+	usbg_state *s;
+	usbg_gadget *g;
+	usbg_config *c;
+	usbg_function *f_ms;
+	int ret = -EINVAL;
+	int usbg_ret;
+	usbg_f_ms_lun_attrs f_ms_luns_array[] = {
+		{
+			.id = -1, /* allows to place in any position */
+			.cdrom = 1,
+			.ro = 0,
+			.nofua = 0,
+			.removable = 1,
+			.filename = "",
+		}, {
+			.id = -1, /* allows to place in any position */
+			.cdrom = 0,
+			.ro = 0,
+			.nofua = 0,
+			.removable = 1,
+			.filename = argv[1],
+		}
+	};
+
+	usbg_f_ms_lun_attrs *f_ms_luns[] = {
+		/*
+		 * When id in lun structure is below 0 we can place it in any
+		 * arbitrary position
+		 */
+		&f_ms_luns_array[1],
+		&f_ms_luns_array[0],
+		NULL,
+	};
+
+	usbg_function_attrs f_attrs = {
+		.header.attrs_type = USBG_F_ATTRS_MS,
+		.attrs.ms = {
+			.stall = 0,
+			.nluns = 2,
+			.luns = f_ms_luns,
+		},
+	};
+
+	usbg_gadget_attrs g_attrs = {
+			0x0200, /* bcdUSB */
+			0x00, /* Defined at interface level */
+			0x00, /* subclass */
+			0x00, /* device protocol */
+			0x0040, /* Max allowed packet size */
+			VENDOR,
+			PRODUCT,
+			0x0001, /* Verson of device */
+	};
+
+	usbg_gadget_strs g_strs = {
+			"0123456789", /* Serial number */
+			"Foo Inc.", /* Manufacturer */
+			"Bar Gadget" /* Product string */
+	};
+
+	usbg_config_strs c_strs = {
+			"1xMass Storage"
+	};
+
+	if (argc < 2) {
+		fprintf(stderr, "Usage: gadget-ms file\n");
+		goto out1;
+	}
+
+	usbg_ret = usbg_init("/sys/kernel/config", &s);
+	if (usbg_ret != USBG_SUCCESS) {
+		fprintf(stderr, "Error on USB gadget init\n");
+		fprintf(stderr, "Error: %s : %s\n", usbg_error_name(usbg_ret),
+				usbg_strerror(usbg_ret));
+		goto out1;
+	}
+
+	usbg_ret = usbg_create_gadget(s, "g1", &g_attrs, &g_strs, &g);
+	if (usbg_ret != USBG_SUCCESS) {
+		fprintf(stderr, "Error on create gadget\n");
+		fprintf(stderr, "Error: %s : %s\n", usbg_error_name(usbg_ret),
+				usbg_strerror(usbg_ret));
+		goto out2;
+	}
+
+	usbg_ret = usbg_create_function(g, F_MASS_STORAGE, "my_reader",
+					&f_attrs, &f_ms);
+	if (usbg_ret != USBG_SUCCESS) {
+		fprintf(stderr, "Error creating mass storage function\n");
+		fprintf(stderr, "Error: %s : %s\n", usbg_error_name(usbg_ret),
+				usbg_strerror(usbg_ret));
+		goto out2;
+	}
+
+	/* NULL can be passed to use kernel defaults */
+	usbg_ret = usbg_create_config(g, 1, "The only one", NULL, &c_strs, &c);
+	if (usbg_ret != USBG_SUCCESS) {
+		fprintf(stderr, "Error creating config\n");
+		fprintf(stderr, "Error: %s : %s\n", usbg_error_name(usbg_ret),
+				usbg_strerror(usbg_ret));
+		goto out2;
+	}
+
+	usbg_ret = usbg_add_config_function(c, "some_name_here", f_ms);
+	if (usbg_ret != USBG_SUCCESS) {
+		fprintf(stderr, "Error adding ms function\n");
+		fprintf(stderr, "Error: %s : %s\n", usbg_error_name(usbg_ret),
+				usbg_strerror(usbg_ret));
+		goto out2;
+	}
+
+	usbg_ret = usbg_enable_gadget(g, DEFAULT_UDC);
+	if (usbg_ret != USBG_SUCCESS) {
+		fprintf(stderr, "Error enabling gadget\n");
+		fprintf(stderr, "Error: %s : %s\n", usbg_error_name(usbg_ret),
+				usbg_strerror(usbg_ret));
+		goto out2;
+	}
+
+	ret = 0;
+
+out2:
+	usbg_cleanup(s);
+
+out1:
+	return ret;
+}

--- a/examples/show-gadgets.c
+++ b/examples/show-gadgets.c
@@ -129,6 +129,23 @@ void show_function(usbg_function *f)
 	case USBG_F_ATTRS_FFS:
 		fprintf(stdout, "    dev_name\t\t%s\n", f_attrs.attrs.ffs.dev_name);
 		break;
+	case USBG_F_ATTRS_MS:
+	{
+		usbg_f_ms_attrs *attrs = &f_attrs.attrs.ms;
+		int i;
+
+		fprintf(stdout, "    stall\t\t%d\n", attrs->stall);
+		fprintf(stdout, "    nluns\t\t%d\n", attrs->nluns);
+		for (i = 0; i < attrs->nluns; ++i) {
+			fprintf(stdout, "    lun %d:\n", attrs->luns[i]->id);
+			fprintf(stdout, "      cdrom\t\t%d\n", attrs->luns[i]->cdrom);
+			fprintf(stdout, "      ro\t\t%d\n", attrs->luns[i]->ro);
+			fprintf(stdout, "      nofua\t\t%d\n", attrs->luns[i]->nofua);
+			fprintf(stdout, "      removable\t\t%d\n", attrs->luns[i]->removable);
+			fprintf(stdout, "      file\t\t%s\n", attrs->luns[i]->filename);
+		}
+		break;
+	}
 	default:
 		fprintf(stdout, "    UNKNOWN\n");
 	}

--- a/include/usbg/usbg.h
+++ b/include/usbg/usbg.h
@@ -22,6 +22,7 @@
 #include <netinet/ether.h>
 #include <stdint.h>
 #include <limits.h>
+#include <stdbool.h>
 #include <stdio.h> /* For FILE * */
 
 #ifdef __cplusplus
@@ -180,6 +181,7 @@ typedef enum
 	F_RNDIS,
 	F_PHONET,
 	F_FFS,
+	F_MASS_STORAGE,
 	USBG_FUNCTION_TYPE_MAX,
 } usbg_function_type;
 
@@ -221,6 +223,29 @@ typedef struct {
 } usbg_f_ffs_attrs;
 
 /**
+ * @typedef usbg_f_ms_attrs
+ * @brief Attributes for mass storage functions
+ */
+typedef struct usbg_f_ms_lun_attrs {
+	int id;
+	bool cdrom;
+	bool ro;
+	bool nofua;
+	bool removable;
+	char *filename;
+} usbg_f_ms_lun_attrs;
+
+/**
+ * @typedef usbg_f_ms_attrs
+ * @brief Attributes for mass storage functions
+ */
+typedef struct {
+	bool stall;
+	int nluns;
+	usbg_f_ms_lun_attrs **luns;
+} usbg_f_ms_attrs;
+
+/**
  * @typedef attrs
  * @brief Attributes for a given function type
  */
@@ -229,6 +254,7 @@ typedef union {
 	usbg_f_net_attrs net;
 	usbg_f_phonet_attrs phonet;
 	usbg_f_ffs_attrs ffs;
+	usbg_f_ms_attrs ms;
 } usbg_f_attrs;
 
 typedef enum {
@@ -236,6 +262,7 @@ typedef enum {
 	USBG_F_ATTRS_NET,
 	USBG_F_ATTRS_PHONET,
 	USBG_F_ATTRS_FFS,
+	USBG_F_ATTRS_MS,
 } usbg_f_attrs_type;
 
 typedef struct {

--- a/include/usbg/usbg_internal.h
+++ b/include/usbg/usbg_internal.h
@@ -74,6 +74,8 @@ struct usbg_config
 	int id;
 };
 
+typedef int (*usbg_rm_function_callback)(usbg_function *, int);
+
 struct usbg_function
 {
 	TAILQ_ENTRY(usbg_function) fnode;
@@ -85,6 +87,7 @@ struct usbg_function
 	/* Only for internal library usage */
 	char *label;
 	usbg_function_type type;
+	usbg_rm_function_callback rm_callback;
 };
 
 struct usbg_binding

--- a/include/usbg/usbg_internal.h
+++ b/include/usbg/usbg_internal.h
@@ -28,6 +28,16 @@
  * @file include/usbg/usbg_internal.h
  */
 
+#ifndef offsetof
+#define offsetof(type, member)  __builtin_offsetof (type, member)
+#endif /* offsetof */
+
+#ifndef container_of
+#define container_of(ptr, type, field) ({                               \
+                        const typeof(((type *)0)->field) *member = (ptr); \
+                        (type *)( (char *)member - offsetof(type, field) ); \
+                })
+#endif /* container_of */
 
 struct usbg_state
 {

--- a/src/usbg.c
+++ b/src/usbg.c
@@ -1354,8 +1354,17 @@ static int usbg_parse_state(usbg_state *s)
 {
 	int ret = USBG_SUCCESS;
 
+	/*
+	 * USBG_ERROR_NOT_FOUND is returned if we are runing on machine where
+	 * there is no udc support in kernel (no /sys/class/udc dir).
+	 * This check allows to run library on such machine or if we don't
+	 * have rights to read this directory.
+	 * User will be able to finish init function and manage gadgets but
+	 * wont be able to bind it as there is no UDC.
+	 */
 	ret = usbg_parse_udcs(s);
-	if (ret != USBG_SUCCESS) {
+	if (ret != USBG_SUCCESS && ret != USBG_ERROR_NOT_FOUND &&
+		ret != USBG_ERROR_NO_ACCESS) {
 		ERROR("Unable to parse udcs");
 		goto out;
 	}

--- a/src/usbg.c
+++ b/src/usbg.c
@@ -26,6 +26,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include <ctype.h>
+#include <stdbool.h>
 #include "usbg/usbg_internal.h"
 
 /**
@@ -433,6 +434,21 @@ static int usbg_read_int(const char *path, const char *name, const char *file,
 #define usbg_read_dec(p, n, f, d)	usbg_read_int(p, n, f, 10, d)
 #define usbg_read_hex(p, n, f, d)	usbg_read_int(p, n, f, 16, d)
 
+static int usbg_read_bool(const char *path, const char *name, const char *file,
+			  bool *dest)
+{
+	int buf;
+	int ret;
+
+	ret = usbg_read_dec(path, name, file, &buf);
+	if (ret != USBG_SUCCESS)
+		goto out;
+
+	*dest = !!buf;
+out:
+	return ret;
+}
+
 static int usbg_read_string(const char *path, const char *name,
 			    const char *file, char *buf)
 {
@@ -521,6 +537,7 @@ static int usbg_write_int(const char *path, const char *name, const char *file,
 #define usbg_write_hex(p, n, f, v)	usbg_write_int(p, n, f, v, "0x%x\n")
 #define usbg_write_hex16(p, n, f, v)	usbg_write_int(p, n, f, v, "0x%04x\n")
 #define usbg_write_hex8(p, n, f, v)	usbg_write_int(p, n, f, v, "0x%02x\n")
+#define usbg_write_bool(p, n, f, v)	usbg_write_dec(p, n, f, !!v)
 
 static inline int usbg_write_string(const char *path, const char *name,
 				    const char *file, const char *buf)

--- a/src/usbg.c
+++ b/src/usbg.c
@@ -2615,26 +2615,30 @@ int usbg_get_function_attrs(usbg_function *f, usbg_function_attrs *f_attrs)
 
 void usbg_cleanup_function_attrs(usbg_function_attrs *f_attrs)
 {
+	usbg_f_attrs *attrs;
+
 	if (!f_attrs)
 		return;
+
+	attrs = &f_attrs->attrs;
 
 	switch (f_attrs->header.attrs_type) {
 	case USBG_F_ATTRS_SERIAL:
 		break;
 
 	case USBG_F_ATTRS_NET:
-		free(f_attrs->attrs.net.ifname);
-		f_attrs->attrs.net.ifname = NULL;
+		free(attrs->net.ifname);
+		attrs->net.ifname = NULL;
 		break;
 
 	case USBG_F_ATTRS_PHONET:
-		free(f_attrs->attrs.phonet.ifname);
-		f_attrs->attrs.phonet.ifname = NULL;
+		free(attrs->phonet.ifname);
+		attrs->phonet.ifname = NULL;
 		break;
 
 	case USBG_F_ATTRS_FFS:
-		free(f_attrs->attrs.ffs.dev_name);
-		f_attrs->attrs.ffs.dev_name = NULL;
+		free(attrs->ffs.dev_name);
+		attrs->ffs.dev_name = NULL;
 		break;
 	default:
 		ERROR("Unsupported attrs type\n");

--- a/src/usbg_schemes_libconfig.c
+++ b/src/usbg_schemes_libconfig.c
@@ -386,7 +386,6 @@ static int usbg_export_function_attrs(usbg_function *f, config_setting_t *root)
 
 	case USBG_F_ATTRS_PHONET:
 		/* Don't export ifname because it is read only */
-		break;
 	case USBG_F_ATTRS_FFS:
 		/* We don't need to export ffs attributes
 		 * due to instance name export */


### PR DESCRIPTION
This series adds support for mass storage function. This has been done in a few steps:
- Add support for mass storage as a function type
- Update show gadget example to properly show also mass storage attributes
- Add example how to create gadget with mass storage function and two luns
- Allow to export mass storage function go scheme file
- Allow to import mass storage function from scheme file what makes mass storage fully supported by libusbg.

This series depends on previous one:
https://github.com/kopasiak/libusbg/pull/4